### PR TITLE
Fix for no Fingerprints in Certificates 

### DIFF
--- a/search_hit.go
+++ b/search_hit.go
@@ -58,7 +58,7 @@ type SearchHostHit struct {
 
 type SearchCertificateHit struct {
 	// FingerprintSha256 is the SHA256 fingerprint of this certificate
-	FingerprintSha256 string `json:"ip"`
+	FingerprintSha256 string `json:"fingerprint_sha256"`
 }
 
 // SmallService is a Service with most fields removed.


### PR DESCRIPTION
The correct Variable in the json response is fingerprint_sha256 not ip for the Fingerprint. If you loop over the Hits you only get an empty return.

https://search.censys.io/api#/certificates%20v2/getSearchCertificates

**Example**
```
	// The third (nil) argument here is an optional *http.Client to use for requests.
	client := censys.NewClient(id, secret, nil)

	results, err := client.SearchCertificates("(labels=`ev`) and (labels=`unexpired`) and (labels=`ever-trusted`)", 10, "")
	if err != nil {
		panic(err)
	}

	fmt.Println(results.Query)
	fmt.Println(results.Total)

	for _, cert := range results.Hits {
		fmt.Println(cert)
	}
```